### PR TITLE
Empty element appears in month and year combobox

### DIFF
--- a/src/components/datepicker.component.html
+++ b/src/components/datepicker.component.html
@@ -35,11 +35,11 @@
                     </ion-icon></span><div class="button-effect"></div>
             </button>
             <select title="Month" name="equiptype" class="form-control" [formControl]="monthChanged" [(ngModel)]="selectedMonth" required>
-                <option></option>
+                
                 <option *ngFor="let mon of months" [ngValue]="mon">{{mon}}</option>
             </select>
             <select title="Month" name="equiptype" class="form-control" [formControl]="yearChanged" [(ngModel)]="selectedYear" required>
-                <option></option>
+                
                 <option *ngFor="let yea of yearsMaxMin" [ngValue]="yea">{{yea}}</option>
             </select>
             <button (click)="nextMonth()" [disabled]="nextDisabled"


### PR DESCRIPTION
When you open the combobox, appears in the beginning an empty element. Appears over January and over 1900. The date that returns when you select this elements is December 1900. In the source code I see that there is an empty field <option> in datepicker.component.html file that it is causing the problem. Can you fix it?